### PR TITLE
Update cffi and numpy to fix install issues (closes #56)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 bcrypt==3.1.7
 certifi==2020.4.5.1
-cffi==1.14.0
+cffi==1.14.1
 chardet==3.0.4
 click==7.1.2
 cycler==0.10.0
@@ -21,7 +21,7 @@ MailGun-V3==0.3.2
 MarkupSafe==1.1.1
 memory-profiler==0.57.0
 more-itertools==8.2.0
-numpy==1.18.4
+numpy==1.26.0
 objgraph==3.4.1
 Paste==3.4.0
 portend==2.6


### PR DESCRIPTION
See, versions below these run into issues with Python 3.10 and Cython 3.

Closes #56 and supersedes #50.